### PR TITLE
Fix memory management bug

### DIFF
--- a/Tests/cpp/InstanceTest.hpp
+++ b/Tests/cpp/InstanceTest.hpp
@@ -5,6 +5,7 @@
 #ifndef TESTS_INSTANCETEST_HPP
 #define TESTS_INSTANCETEST_HPP
 
+#include <vector>
 #include "Jni/Jni.hpp"
 
 using namespace gusc::Jni;
@@ -20,6 +21,15 @@ void runInstanceTestMethodsAndFields(JObject& obj)
     jfloat g = 6.3f;
     jdouble h = 20.2;
     auto i = JString::createFrom("test 2");
+    auto j = JBooleanArray::createFrom({ false, true, true, false });
+    auto k = JByteArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+    auto l = JCharArray::createFrom({ 'd', 'c', 'b', 'a' });
+    auto m = JShortArray ::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+    auto n = JIntArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+    auto o = JLongArray::createFrom({ 1234567890, 1234567891, 1234567892, 1234567893 });
+    auto p = JFloatArray::createFrom({ 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f, 0.f });
+    auto q = JDoubleArray::createFrom({ 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0 });
+
 
     obj.invokeMethod<void>("voidMethodNoArgs");
     obj.invokeMethod<void>("setBoolean", a);
@@ -31,6 +41,14 @@ void runInstanceTestMethodsAndFields(JObject& obj)
     obj.invokeMethod<void>("setFloat", g);
     obj.invokeMethod<void>("setDouble", h);
     obj.invokeMethod<void>("setString", static_cast<jstring>(i));
+    obj.invokeMethod<void>("setBooleanArray", static_cast<jbooleanArray>(j));
+    obj.invokeMethod<void>("setByteArray", static_cast<jbyteArray>(k));
+    obj.invokeMethod<void>("setCharArray", static_cast<jcharArray>(l));
+    obj.invokeMethod<void>("setShortArray", static_cast<jshortArray>(m));
+    obj.invokeMethod<void>("setIntArray", static_cast<jintArray>(n));
+    obj.invokeMethod<void>("setLongArray", static_cast<jlongArray>(o));
+    obj.invokeMethod<void>("setFloatArray", static_cast<jfloatArray>(p));
+    obj.invokeMethod<void>("setDoubleArray", static_cast<jdoubleArray>(q));
 
     a = obj.invokeMethod<jboolean>("getBoolean");
     b = obj.invokeMethod<jbyte>("getByte");
@@ -41,6 +59,14 @@ void runInstanceTestMethodsAndFields(JObject& obj)
     g = obj.invokeMethod<jfloat>("getFloat");
     h = obj.invokeMethod<jdouble>("getDouble");
     i = obj.invokeMethod<JString>("getString");
+    j = obj.invokeMethod<jbooleanArray>("getBooleanArray");
+    k = obj.invokeMethod<jbyteArray>("getByteArray");
+    l = obj.invokeMethod<jcharArray>("getCharArray");
+    m = obj.invokeMethod<jshortArray>("getShortArray");
+    n = obj.invokeMethod<jintArray>("getIntArray");
+    o = obj.invokeMethod<jlongArray>("getLongArray");
+    p = obj.invokeMethod<jfloatArray>("getFloatArray");
+    q = obj.invokeMethod<jdoubleArray>("getDoubleArray");
 
     obj.setField("booleanField", a);
     obj.setField("byteField", b);
@@ -51,6 +77,14 @@ void runInstanceTestMethodsAndFields(JObject& obj)
     obj.setField("floatField", g);
     obj.setField("doubleField", h);
     obj.setField("stringField", i);
+    obj.setField("booleanArrayField", static_cast<jbooleanArray>(j));
+    obj.setField("byteArrayField", static_cast<jbyteArray>(k));
+    obj.setField("charArrayField", static_cast<jcharArray>(l));
+    obj.setField("shortArrayField", static_cast<jshortArray>(m));
+    obj.setField("intArrayField", static_cast<jintArray>(n));
+    obj.setField("longArrayField", static_cast<jlongArray>(o));
+    obj.setField("floatArrayField", static_cast<jfloatArray>(p));
+    obj.setField("doubleArrayField", static_cast<jdoubleArray>(q));
 
     a = obj.getField<jboolean>("booleanField");
     b = obj.getField<jbyte>("byteField");
@@ -61,6 +95,14 @@ void runInstanceTestMethodsAndFields(JObject& obj)
     g = obj.getField<jfloat>("floatField");
     h = obj.getField<jdouble>("doubleField");
     i = obj.getField<JString>("stringField");
+    j = obj.getField<jbooleanArray>("booleanArrayField");
+    k = obj.getField<jbyteArray>("byteArrayField");
+    l = obj.getField<jcharArray>("charArrayField");
+    m = obj.getField<jshortArray>("shortArrayField");
+    n = obj.getField<jintArray>("intArrayField");
+    o = obj.getField<jlongArray>("longArrayField");
+    p = obj.getField<jfloatArray>("floatArrayField");
+    q = obj.getField<jdoubleArray>("doubleArrayField");
 
     obj.invokeMethod<void>("voidMethod", a, b, c, d, e, f, g, h, static_cast<jstring>(i));
 
@@ -84,7 +126,25 @@ void runInstanceTest()
         jfloat g = 5.0f;
         jdouble h = 10.0;
         auto i = JString::createFrom("test");
-        auto obj = cls.createObject(a, b, c, d, e, f, g, h, static_cast<jstring>(i));
+        auto j = JBooleanArray::createFrom({ false, true, true, false });
+        auto k = JByteArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+        auto l = JCharArray::createFrom({ 'd', 'c', 'b', 'a' });
+        auto m = JShortArray ::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+        auto n = JIntArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+        auto o = JLongArray::createFrom({ 1234567890, 1234567891, 1234567892, 1234567893 });
+        auto p = JFloatArray::createFrom({ 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f, 0.f });
+        auto q = JDoubleArray::createFrom({ 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0 });
+
+        auto obj = cls.createObject(a, b, c, d, e, f, g, h, static_cast<jstring>(i),
+                                    static_cast<jbooleanArray>(j),
+                                    static_cast<jbyteArray>(k),
+                                    static_cast<jcharArray>(l),
+                                    static_cast<jshortArray>(m),
+                                    static_cast<jintArray>(n),
+                                    static_cast<jlongArray>(o),
+                                    static_cast<jfloatArray>(p),
+                                    static_cast<jdoubleArray>(q)
+                                    );
         runInstanceTestMethodsAndFields(obj);
     }
 

--- a/Tests/cpp/NativeClassTest.hpp
+++ b/Tests/cpp/NativeClassTest.hpp
@@ -125,7 +125,82 @@ public:
 
     jstring nativeStringMethod(jstring val)
     {
-        //JString tmp = JString::createFrom(static_cast<std::string>(i));
+        // TODO: implement reference copies in C++
+//        JString tmp = i;
+//        i = val;
+//        return static_cast<jstring>(tmp);
+        return val;
+    }
+
+    jbooleanArray nativeBooleanArrayMethod(jbooleanArray val)
+    {
+//        JBooleanArray tmp = j;
+//        j = val;
+//        return static_cast<jbooleanArray>(tmp);
+        return val;
+    }
+
+    jbyteArray nativeByteArrayMethod(jbyteArray val)
+    {
+//        JByteArray tmp = k;
+//        k = val;
+//        return static_cast<jbyteArray>(tmp);
+        return val;
+    }
+
+    jcharArray nativeCharArrayMethod(jcharArray val)
+    {
+//        JCharArray tmp = l;
+//        l = val;
+//        return static_cast<jcharArray>(tmp);
+        return val;
+    }
+
+    jshortArray nativeShortArrayMethod(jshortArray val)
+    {
+//        JShortArray tmp = m;
+//        m = val;
+//        return static_cast<jshortArray>(tmp);
+        return val;
+    }
+
+    jintArray nativeIntArrayMethod(jintArray val)
+    {
+//        JIntArray tmp = n;
+//        n = val;
+//        return static_cast<jintArray>(tmp);
+        return val;
+    }
+
+    jlongArray nativeLongArrayMethod(jlongArray val)
+    {
+//        JLongArray tmp = o;
+//        o = val;
+//        return static_cast<jlongArray>(tmp);
+        return val;
+    }
+
+    jfloatArray nativeFloatArrayMethod(jfloatArray val)
+    {
+//        JFloatArray tmp = p;
+//        p = val;
+//        return static_cast<jfloatArray>(tmp);
+        return val;
+    }
+
+    jdoubleArray nativeDoubleArrayMethod(jdoubleArray val)
+    {
+//        JDoubleArray tmp = q;
+//        q = val;
+//        return static_cast<jdoubleArray>(q);
+        return val;
+    }
+
+    jobjectArray nativeObjectArrayMethod(jobjectArray val)
+    {
+//        JObjectArray tmp = q;
+//        q = val;
+//        return static_cast<jobjectArray>(q);
         return val;
     }
 
@@ -144,6 +219,14 @@ public:
         cls.registerNativeMethod("nativeFloatMethod", &NativeClassTest::nativeFloatMethodJni);
         cls.registerNativeMethod("nativeDoubleMethod", &NativeClassTest::nativeDoubleMethodJni);
         cls.registerNativeMethod("nativeStringMethod", &NativeClassTest::nativeStringMethodJni);
+        cls.registerNativeMethod("nativeBooleanArrayMethod", &NativeClassTest::nativeBooleanArrayMethodJni);
+        cls.registerNativeMethod("nativeByteArrayMethod", &NativeClassTest::nativeByteArrayMethodJni);
+        cls.registerNativeMethod("nativeCharArrayMethod", &NativeClassTest::nativeCharArrayMethodJni);
+        cls.registerNativeMethod("nativeShortArrayMethod", &NativeClassTest::nativeShortArrayMethodJni);
+        cls.registerNativeMethod("nativeIntArrayMethod", &NativeClassTest::nativeIntArrayMethodJni);
+        cls.registerNativeMethod("nativeLongArrayMethod", &NativeClassTest::nativeLongArrayMethodJni);
+        cls.registerNativeMethod("nativeFloatArrayMethod", &NativeClassTest::nativeFloatArrayMethodJni);
+        cls.registerNativeMethod("nativeDoubleArrayMethod", &NativeClassTest::nativeDoubleArrayMethodJni);
     }
 private:
     JGlobalRef objRef;
@@ -156,6 +239,14 @@ private:
     jfloat g { 1.f };
     jdouble h { 2.0 };
     JString i { JString::createFrom("asdf") };
+    JBooleanArray j { JBooleanArray::createFrom({ false, true, true, false }) };
+    JByteArray k { JByteArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }) };
+    JCharArray l = { JCharArray::createFrom({ 'd', 'c', 'b', 'a' }) };
+    JShortArray m = { JShortArray ::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }) };
+    JIntArray n = { JIntArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 }) };
+    JLongArray o = { JLongArray::createFrom({ 1234567890, 1234567891, 1234567892, 1234567893 }) };
+    JFloatArray p = { JFloatArray::createFrom({ 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f, 0.f }) };
+    JDoubleArray q = { JDoubleArray::createFrom({ 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0 }) };
 
     static void nativeVoidMethodNoArgsJni(JNIEnv*, jobject thiz)
     {
@@ -211,6 +302,46 @@ private:
     {
         auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
         return ptr->nativeStringMethod(val);
+    }
+    static jbooleanArray nativeBooleanArrayMethodJni(JNIEnv*, jobject thiz, jbooleanArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeBooleanArrayMethod(val);
+    }
+    static jbyteArray nativeByteArrayMethodJni(JNIEnv*, jobject thiz, jbyteArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeByteArrayMethod(val);
+    }
+    static jcharArray nativeCharArrayMethodJni(JNIEnv*, jobject thiz, jcharArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeCharArrayMethod(val);
+    }
+    static jshortArray nativeShortArrayMethodJni(JNIEnv*, jobject thiz, jshortArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeShortArrayMethod(val);
+    }
+    static jintArray nativeIntArrayMethodJni(JNIEnv*, jobject thiz, jintArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeIntArrayMethod(val);
+    }
+    static jlongArray nativeLongArrayMethodJni(JNIEnv*, jobject thiz, jlongArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeLongArrayMethod(val);
+    }
+    static jfloatArray nativeFloatArrayMethodJni(JNIEnv*, jobject thiz, jfloatArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeFloatArrayMethod(val);
+    }
+    static jdoubleArray nativeDoubleArrayMethodJni(JNIEnv*, jobject thiz, jdoubleArray val)
+    {
+        auto ptr = toPtr<NativeClassTest>(JObject(thiz).getField<jlong>("nativePtr"));
+        return ptr->nativeDoubleArrayMethod(val);
     }
 };
 

--- a/Tests/cpp/StaticTest.hpp
+++ b/Tests/cpp/StaticTest.hpp
@@ -20,6 +20,14 @@ void runStaticTestMethodsAndFields(JClass& cls)
     jfloat g = 6.3f;
     jdouble h = 20.2;
     auto i = JString::createFrom("test 2");
+    auto j = JBooleanArray::createFrom({ false, true, true, false });
+    auto k = JByteArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+    auto l = JCharArray::createFrom({ 'd', 'c', 'b', 'a' });
+    auto m = JShortArray ::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+    auto n = JIntArray::createFrom({ 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 });
+    auto o = JLongArray::createFrom({ 1234567890, 1234567891, 1234567892, 1234567893 });
+    auto p = JFloatArray::createFrom({ 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f, 0.f });
+    auto q = JDoubleArray::createFrom({ 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0 });
 
     cls.invokeMethod<void>("voidMethodNoArgs");
     cls.invokeMethod<void>("setBoolean", a);
@@ -31,6 +39,14 @@ void runStaticTestMethodsAndFields(JClass& cls)
     cls.invokeMethod<void>("setFloat", g);
     cls.invokeMethod<void>("setDouble", h);
     cls.invokeMethod<void>("setString", static_cast<jstring>(i));
+    cls.invokeMethod<void>("setBooleanArray", static_cast<jbooleanArray>(j));
+    cls.invokeMethod<void>("setByteArray", static_cast<jbyteArray>(k));
+    cls.invokeMethod<void>("setCharArray", static_cast<jcharArray>(l));
+    cls.invokeMethod<void>("setShortArray", static_cast<jshortArray>(m));
+    cls.invokeMethod<void>("setIntArray", static_cast<jintArray>(n));
+    cls.invokeMethod<void>("setLongArray", static_cast<jlongArray>(o));
+    cls.invokeMethod<void>("setFloatArray", static_cast<jfloatArray>(p));
+    cls.invokeMethod<void>("setDoubleArray", static_cast<jdoubleArray>(q));
 
     a = cls.invokeMethod<jboolean>("getBoolean");
     b = cls.invokeMethod<jbyte>("getByte");
@@ -41,6 +57,14 @@ void runStaticTestMethodsAndFields(JClass& cls)
     g = cls.invokeMethod<jfloat>("getFloat");
     h = cls.invokeMethod<jdouble>("getDouble");
     i = cls.invokeMethod<jstring>("getString");
+    j = cls.invokeMethod<jbooleanArray>("getBooleanArray");
+    k = cls.invokeMethod<jbyteArray>("getByteArray");
+    l = cls.invokeMethod<jcharArray>("getCharArray");
+    m = cls.invokeMethod<jshortArray>("getShortArray");
+    n = cls.invokeMethod<jintArray>("getIntArray");
+    o = cls.invokeMethod<jlongArray>("getLongArray");
+    p = cls.invokeMethod<jfloatArray>("getFloatArray");
+    q = cls.invokeMethod<jdoubleArray>("getDoubleArray");
 
     cls.setField("booleanField", a);
     cls.setField("byteField", b);
@@ -51,6 +75,14 @@ void runStaticTestMethodsAndFields(JClass& cls)
     cls.setField("floatField", g);
     cls.setField("doubleField", h);
     cls.setField("stringField", i);
+    cls.setField("booleanArrayField", static_cast<jbooleanArray>(j));
+    cls.setField("byteArrayField", static_cast<jbyteArray>(k));
+    cls.setField("charArrayField", static_cast<jcharArray>(l));
+    cls.setField("shortArrayField", static_cast<jshortArray>(m));
+    cls.setField("intArrayField", static_cast<jintArray>(n));
+    cls.setField("longArrayField", static_cast<jlongArray>(o));
+    cls.setField("floatArrayField", static_cast<jfloatArray>(p));
+    cls.setField("doubleArrayField", static_cast<jdoubleArray>(q));
 
     a = cls.getField<jboolean>("booleanField");
     b = cls.getField<jbyte>("byteField");
@@ -61,6 +93,14 @@ void runStaticTestMethodsAndFields(JClass& cls)
     g = cls.getField<jfloat>("floatField");
     h = cls.getField<jdouble>("doubleField");
     i = cls.getField<jstring>("stringField");
+    j = cls.getField<jbooleanArray>("booleanArrayField");
+    k = cls.getField<jbyteArray>("byteArrayField");
+    l = cls.getField<jcharArray>("charArrayField");
+    m = cls.getField<jshortArray>("shortArrayField");
+    n = cls.getField<jintArray>("intArrayField");
+    o = cls.getField<jlongArray>("longArrayField");
+    p = cls.getField<jfloatArray>("floatArrayField");
+    q = cls.getField<jdoubleArray>("doubleArrayField");
 
     cls.invokeMethod<void>("voidMethod", a, b, c, d, e, f, g, h, static_cast<jstring>(i));
 

--- a/Tests/java/lv/gusc/jni/tests/InstanceTest.java
+++ b/Tests/java/lv/gusc/jni/tests/InstanceTest.java
@@ -13,13 +13,22 @@ public class InstanceTest {
     public float floatField = 1.5f;
     public double doubleField = 2.3;
     public String stringField = "asdf";
+    public boolean[] booleanArrayField = {false, true};
+    public byte[] byteArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public char[] charArrayField = {'a', 'b', 'c', 'd'};
+    public short[] shortArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public int[] intArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public long[] longArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public float[] floatArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public double[] doubleArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
 
     @Keep
     InstanceTest() {
     }
 
     @Keep
-    InstanceTest(boolean a, byte b, char c, short d, int e, long f, float g, double h, String i) {
+    InstanceTest(boolean a, byte b, char c, short d, int e, long f, float g, double h, String i,
+                 boolean[] j, byte[] k, char[] l, short[] m, int[] n, long[] o, float[] p, double[] q) {
         booleanField = a;
         byteField = b;
         charField = c;
@@ -29,6 +38,14 @@ public class InstanceTest {
         floatField = g;
         doubleField = h;
         stringField = i;
+        booleanArrayField = j;
+        byteArrayField = k;
+        charArrayField = l;
+        shortArrayField = m;
+        intArrayField = n;
+        longArrayField = o;
+        floatArrayField = p;
+        doubleArrayField = q;
     }
 
     @Keep
@@ -94,6 +111,46 @@ public class InstanceTest {
     }
 
     @Keep
+    boolean[] getBooleanArray() {
+        return booleanArrayField;
+    }
+
+    @Keep
+    byte[] getByteArray() {
+        return byteArrayField;
+    }
+
+    @Keep
+    char[] getCharArray() {
+        return charArrayField;
+    }
+
+    @Keep
+    short[] getShortArray() {
+        return shortArrayField;
+    }
+
+    @Keep
+    int[] getIntArray() {
+        return intArrayField;
+    }
+
+    @Keep
+    long[] getLongArray() {
+        return longArrayField;
+    }
+
+    @Keep
+    float[] getFloatArray() {
+        return floatArrayField;
+    }
+
+    @Keep
+    double[] getDoubleArray() {
+        return doubleArrayField;
+    }
+
+    @Keep
     void setBoolean(boolean val) {
         booleanField = val;
     }
@@ -136,5 +193,41 @@ public class InstanceTest {
     @Keep
     void setString(String val) {
         stringField = val;
+    }
+
+    @Keep
+    void setBooleanArray(boolean[] val) {
+        booleanArrayField = val;
+    }
+
+    @Keep
+    void setByteArray(byte[] val) {
+        byteArrayField = val;
+    }
+
+    @Keep
+    void setCharArray(char[] val) {
+        charArrayField = val;
+    }
+
+    @Keep
+    void setShortArray(short[] val) {
+        shortArrayField = val;
+    }
+    @Keep
+    void setIntArray(int[] val) {
+        intArrayField = val;
+    }
+    @Keep
+    void setLongArray(long[] val) {
+        longArrayField = val;
+    }
+    @Keep
+    void setFloatArray(float[] val) {
+        floatArrayField = val;
+    }
+    @Keep
+    void setDoubleArray(double[] val) {
+        doubleArrayField = val;
     }
 }

--- a/Tests/java/lv/gusc/jni/tests/NativeClassTest.java
+++ b/Tests/java/lv/gusc/jni/tests/NativeClassTest.java
@@ -24,6 +24,14 @@ public class NativeClassTest {
         float g = 1.5f;
         double h = 2.3;
         String i = "asdf";
+        boolean[] j = {false, true};
+        byte[] k = {0, 1, 2, 3, 4, 5, 6, 7};
+        char[] l = {'a', 'b', 'c', 'd'};
+        short[] m = {0, 1, 2, 3, 4, 5, 6, 7};
+        int[] n = {0, 1, 2, 3, 4, 5, 6, 7};
+        long[] o = {0, 1, 2, 3, 4, 5, 6, 7};
+        float[] p = {0, 1, 2, 3, 4, 5, 6, 7};
+        double[] q = {0, 1, 2, 3, 4, 5, 6, 7};
 
         nativeVoidMethodNoArgs();
         a = nativeBooleanMethod(a);
@@ -35,6 +43,14 @@ public class NativeClassTest {
         g = nativeFloatMethod(g);
         h = nativeDoubleMethod(h);
         i = nativeStringMethod(i);
+        j = nativeBooleanArrayMethod(j);
+        k = nativeByteArrayMethod(k);
+        l = nativeCharArrayMethod(l);
+        m = nativeShortArrayMethod(m);
+        n = nativeIntArrayMethod(n);
+        o = nativeLongArrayMethod(o);
+        p = nativeFloatArrayMethod(p);
+        q = nativeDoubleArrayMethod(q);
         nativeVoidMethod(a, b, c, d, e, f, g, h , i);
     }
 
@@ -49,4 +65,13 @@ public class NativeClassTest {
     native float nativeFloatMethod(float val);
     native double nativeDoubleMethod(double val);
     native String nativeStringMethod(String val);
+    native boolean[] nativeBooleanArrayMethod(boolean[] val);
+    native byte[] nativeByteArrayMethod(byte[] val);
+    native char[] nativeCharArrayMethod(char[] val);
+    native short[] nativeShortArrayMethod(short[] val);
+    native int[] nativeIntArrayMethod(int[] val);
+    native long[] nativeLongArrayMethod(long[] val);
+    native float[] nativeFloatArrayMethod(float[] val);
+    native double[] nativeDoubleArrayMethod(double[] val);
+
 }

--- a/Tests/java/lv/gusc/jni/tests/StaticTest.java
+++ b/Tests/java/lv/gusc/jni/tests/StaticTest.java
@@ -13,6 +13,14 @@ public class StaticTest {
     public static float floatField = 1.5f;
     public static double doubleField = 2.3;
     public static String stringField = "asdf";
+    public static boolean[] booleanArrayField = {false, true};
+    public static byte[] byteArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public static char[] charArrayField = {'a', 'b', 'c', 'd'};
+    public static short[] shortArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public static int[] intArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public static long[] longArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public static float[] floatArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
+    public static double[] doubleArrayField = {0, 1, 2, 3, 4, 5, 6, 7};
 
     @Keep
     static void voidMethodNoArgs() {
@@ -76,6 +84,47 @@ public class StaticTest {
         return stringField;
     }
 
+
+    @Keep
+    static boolean[] getBooleanArray() {
+        return booleanArrayField;
+    }
+
+    @Keep
+    static byte[] getByteArray() {
+        return byteArrayField;
+    }
+
+    @Keep
+    static char[] getCharArray() {
+        return charArrayField;
+    }
+
+    @Keep
+    static short[] getShortArray() {
+        return shortArrayField;
+    }
+
+    @Keep
+    static int[] getIntArray() {
+        return intArrayField;
+    }
+
+    @Keep
+    static long[] getLongArray() {
+        return longArrayField;
+    }
+
+    @Keep
+    static float[] getFloatArray() {
+        return floatArrayField;
+    }
+
+    @Keep
+    static double[] getDoubleArray() {
+        return doubleArrayField;
+    }
+
     @Keep
     static void setBoolean(boolean val) {
         booleanField = val;
@@ -119,5 +168,41 @@ public class StaticTest {
     @Keep
     static void setString(String val) {
         stringField = val;
+    }
+
+    @Keep
+    static void setBooleanArray(boolean[] val) {
+        booleanArrayField = val;
+    }
+
+    @Keep
+    static void setByteArray(byte[] val) {
+        byteArrayField = val;
+    }
+
+    @Keep
+    static void setCharArray(char[] val) {
+        charArrayField = val;
+    }
+
+    @Keep
+    static void setShortArray(short[] val) {
+        shortArrayField = val;
+    }
+    @Keep
+    static void setIntArray(int[] val) {
+        intArrayField = val;
+    }
+    @Keep
+    static void setLongArray(long[] val) {
+        longArrayField = val;
+    }
+    @Keep
+    static void setFloatArray(float[] val) {
+        floatArrayField = val;
+    }
+    @Keep
+    static void setDoubleArray(double[] val) {
+        doubleArrayField = val;
     }
 }

--- a/include/Jni/JObject.hpp
+++ b/include/Jni/JObject.hpp
@@ -13,6 +13,13 @@ namespace gusc::Jni
 
 class JClass;
 
+// TODO:
+// 1. make JArray and JString objects extend from JObject
+// 2. drop current ownership in favor of always creating a reference copy
+// 3. make it possible to copy objects taking into account their reference type (global, local, weak)
+// note: maybe 2&3 can be somehow combined with some optimization for when creating object from raw
+//       jtype we do not copy reference, but if we copy from JObject to another then we do
+// 4. instead of JGlobalRef create method in JObject to create global or weak references that just copies the object
 class JObject final
 {
 public:
@@ -340,12 +347,21 @@ protected:
     template<typename TReturn, typename... TArgs>
     inline
     typename std::enable_if_t<
-            std::is_same_v<TReturn, jstring>,
+            !std::is_same_v<TReturn, jboolean> &&
+            !std::is_same_v<TReturn, jbyte> &&
+            !std::is_same_v<TReturn, jchar> &&
+            !std::is_same_v<TReturn, jshort> &&
+            !std::is_same_v<TReturn, jint> &&
+            !std::is_same_v<TReturn, jlong> &&
+            !std::is_same_v<TReturn, jfloat> &&
+            !std::is_same_v<TReturn, jdouble> &&
+            !std::is_same_v<TReturn, JString> &&
+            !std::is_same_v<TReturn, JObject>,
             TReturn
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return static_cast<jstring>(env->CallObjectMethod(obj, methodId, std::forward<const TArgs&>(args)...));
+        return static_cast<TReturn>(env->CallObjectMethod(obj, methodId, std::forward<const TArgs&>(args)...));
     }
 
     template<typename TReturn, typename... TArgs>
@@ -362,23 +378,12 @@ protected:
     template<typename TReturn, typename... TArgs>
     inline
     typename std::enable_if_t<
-        std::is_same_v<TReturn, jobject>,
-        TReturn
-    >
-    invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
-    {
-        return env->CallObjectMethod(obj, methodId, std::forward<const TArgs&>(args)...);
-    }
-
-    template<typename TReturn, typename... TArgs>
-    inline
-    typename std::enable_if_t<
         std::is_same_v<TReturn, JObject>,
         TReturn
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return JObject(env->CallObjectMethod(obj, methodId, std::forward<const TArgs&>(args)...));
+        return JObject(invokeMethodReturn<jobject>(env, methodId, std::forward<const TArgs&>(args)...));
     }
 
     template<typename T>
@@ -472,12 +477,21 @@ protected:
     template<typename T>
     inline
     typename std::enable_if_t<
-        std::is_same_v<T, jstring>,
+        !std::is_same_v<T, jboolean> &&
+        !std::is_same_v<T, jbyte> &&
+        !std::is_same_v<T, jchar> &&
+        !std::is_same_v<T, jshort> &&
+        !std::is_same_v<T, jint> &&
+        !std::is_same_v<T, jlong> &&
+        !std::is_same_v<T, jfloat> &&
+        !std::is_same_v<T, jdouble> &&
+        !std::is_same_v<T, JString> &&
+        !std::is_same_v<T, JObject>,
         T
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return static_cast<jstring>(env->GetObjectField(obj, fieldId));
+        return static_cast<T>(env->GetObjectField(obj, fieldId));
     }
 
     template<typename T>
@@ -494,41 +508,12 @@ protected:
     template<typename T>
     inline
     typename std::enable_if_t<
-        std::is_same_v<T, jobject>,
-        T
-    >
-    getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
-    {
-        return env->GetObjectField(obj, fieldId);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<
         std::is_same_v<T, JObject>,
         T
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
         return JObject(getFieldValue<jobject>(env, fieldId), true);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<
-            std::is_same_v<T, jbyteArray> ||
-            std::is_same_v<T, jcharArray> ||
-            std::is_same_v<T, jshortArray> ||
-            std::is_same_v<T, jintArray> ||
-            std::is_same_v<T, jlongArray> ||
-            std::is_same_v<T, jfloatArray> ||
-            std::is_same_v<T, jdoubleArray> ||
-            std::is_same_v<T, jobjectArray>,
-            T
-    >
-    getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
-    {
-        return static_cast<T>(getFieldValue<jobject>(env, fieldId));
     }
 
     template<typename T>
@@ -614,9 +599,16 @@ protected:
     template<typename T>
     inline void setFieldValue(JEnv& env, jfieldID fieldId,
                               typename std::enable_if_t<
-                                  std::is_same_v<T, jstring> ||
-                                  std::is_same_v<T, jobject> ||
-                                  std::is_same_v<T, JObject>,
+                                  !std::is_same_v<T, jboolean> &&
+                                  !std::is_same_v<T, jbyte> &&
+                                  !std::is_same_v<T, jchar> &&
+                                  !std::is_same_v<T, jshort> &&
+                                  !std::is_same_v<T, jint> &&
+                                  !std::is_same_v<T, jlong> &&
+                                  !std::is_same_v<T, jfloat> &&
+                                  !std::is_same_v<T, jdouble> &&
+                                  !std::is_same_v<T, JObject> &&
+                                  !std::is_same_v<T, JString>,
                                   const T&
                               > value) noexcept
     {
@@ -636,14 +628,7 @@ protected:
     template<typename T>
     inline void setFieldValue(JEnv& env, jfieldID fieldId,
                               typename std::enable_if_t<
-                                      std::is_same_v<T, jbyteArray> ||
-                                      std::is_same_v<T, jcharArray> ||
-                                      std::is_same_v<T, jshortArray> ||
-                                      std::is_same_v<T, jintArray> ||
-                                      std::is_same_v<T, jlongArray> ||
-                                      std::is_same_v<T, jfloatArray> ||
-                                      std::is_same_v<T, jdoubleArray> ||
-                                      std::is_same_v<T, jobjectArray>,
+                                      std::is_same_v<T, JObject>,
                                       const T&
                               > value) noexcept
     {


### PR DESCRIPTION
It was brought to my attention that in JNI j*Array Get*ArrayElements methods the isCopy does not stand for ownership of the pointer, so in case we didn't get a "copy" we would leak memory. This pull request fixes that and implements j*Array test cases