### PR TITLE
2 object ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Tests/.idea
 Tests/build_android
 Tests/build_cmake
+.DS_Store

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3,6 +3,21 @@ project(JniTests VERSION 1.0.0 LANGUAGES CXX)
 
 set(SOURCES
 	"cpp/main.cpp"
+	"cpp/InstanceTest.hpp"
+	"cpp/NativeClassTest.hpp"
+	"cpp/StaticTest.hpp"
+	# Adding these to ease development in Android Studio
+	"../include/Jni/JClass.hpp"
+	"../include/Jni/JEnv.hpp"
+	"../include/Jni/JGlobalRef.hpp"
+	"../include/Jni/Jni.hpp"
+	"../include/Jni/JObject.hpp"
+	"../include/Jni/JVM.hpp"
+	"../include/Jni/JArray.hpp"
+	"../include/Jni/JString.hpp"
+	"../include/Jni/private/cast.hpp"
+	"../include/Jni/private/concat.hpp"
+	"../include/Jni/private/signature.hpp"
 )
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES})

--- a/include/Jni/JArray.hpp
+++ b/include/Jni/JArray.hpp
@@ -12,12 +12,11 @@ class JArray final : public JObject
     class JArrayData final
     {
     public:
-        JArrayData(const TJArray& initArray)
+        JArrayData(JEnv env, const TJArray& initArray)
             : jniArray(initArray)
         {
             if (jniArray)
             {
-                auto env = JVM::getEnv();
                 length = env->GetArrayLength(jniArray);
                 dataPtr = getDataPtr(env);
             }
@@ -188,7 +187,7 @@ public:
 
     inline operator TCpp()
     {
-        JArrayData data(static_cast<TJArray>(jniObject));
+        JArrayData data(JVM::getEnv(), static_cast<TJArray>(jniObject));
         return static_cast<TCpp>(data);
     }
 
@@ -199,7 +198,7 @@ public:
 
     inline JArrayData getData() const
     {
-        return static_cast<TJArray>(jniObject);
+        return JArrayData(JVM::getEnv(), static_cast<TJArray>(jniObject));
     }
 
     template<typename T=TJArray>

--- a/include/Jni/JArray.hpp
+++ b/include/Jni/JArray.hpp
@@ -30,6 +30,11 @@ class JArray final : public JObject
             return TCpp(dataPtr, dataPtr + length);
         }
 
+        inline TJArrayElement* data() const
+        {
+            return dataPtr;
+        }
+
         ~JArrayData()
         {
             if (jniArray && dataPtr)
@@ -192,10 +197,10 @@ public:
         return static_cast<TJArray>(jniObject);
     }
 
-//    inline TJArrayElement* data()
-//    {
-//        return dataPtr;
-//    }
+    inline JArrayData getData() const
+    {
+        return static_cast<TJArray>(jniObject);
+    }
 
     template<typename T=TJArray>
     static inline

--- a/include/Jni/JArray.hpp
+++ b/include/Jni/JArray.hpp
@@ -2,363 +2,353 @@
 #define __GUSC_JARRAY_HPP 1
 
 #include <jni.h>
-#include "JVM.hpp"
-#include "JEnv.hpp"
 
 namespace gusc::Jni
 {
 
-template<typename TCpp=std::vector<std::int8_t>, typename TJni=jbyteArray, typename TJniEl=jbyte>
-class JArray
+template<typename TCpp=std::vector<std::int8_t>, typename TJArray=jbyteArray, typename TJArrayElement=jbyte>
+class JArray final : public JObject
 {
-public:
-    JArray(JEnv env, TJni initArray)
-        : jniArray(initArray)
+    class JArrayData final
     {
-        init(env);
-    }
-    JArray(TJni initArray)
-        : JArray(JVM::getEnv(), initArray)
-    {}
-    JArray(JEnv env, std::size_t initSize)
-    {
-        create<TJni>(env, initSize);
-        init(env);
-    }
-    JArray(std::size_t initSize)
-        : JArray(JVM::getEnv(), initSize)
-    {}
-    JArray(const JArray<TCpp>& other) = delete;
-    JArray& operator = (const JArray<TCpp>& other) = delete;
-    JArray(JArray&& other) = default;
-    JArray& operator=(JArray&& other)
-    {
-        dispose();
-        jniArray = nullptr;
-        std::swap(jniArray, other.jniArray);
-        std::swap(length, other.length);
-        std::swap(dataPtr, other.dataPtr);
-        return *this;
-    }
-    ~JArray()
-    {
-        dispose();
-    }
-    inline operator TCpp()
-    {
-        if (dataPtr)
+    public:
+        JArrayData(const TJArray& initArray)
+            : jniArray(initArray)
+        {
+            if (jniArray)
+            {
+                auto env = JVM::getEnv();
+                length = env->GetArrayLength(jniArray);
+                dataPtr = getDataPtr(env);
+            }
+        }
+        JArrayData(const JArrayData&) = delete;
+        JArrayData& operator=(const JArrayData&) = delete;
+
+        inline operator TCpp() const
         {
             return TCpp(dataPtr, dataPtr + length);
         }
-        return {};
-    }
-    inline operator TJni()
+
+        ~JArrayData()
+        {
+            if (jniArray && dataPtr)
+            {
+                auto env = JVM::getEnv();
+                freeDataPtr(env);
+                dataPtr = nullptr;
+                length = 0;
+            }
+        }
+    private:
+        TJArray jniArray { nullptr };
+        std::size_t length { 0 };
+        const TJArrayElement* dataPtr { nullptr };
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jcharArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetCharArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jbyteArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetByteArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jshortArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetShortArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jintArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetIntArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jlongArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetLongArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jfloatArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetFloatArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetDoubleArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, TJArrayElement*>
+        getDataPtr(JEnv& env)
+        {
+            return env->GetBooleanArrayElements(jniArray, nullptr);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jbyteArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseByteArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jcharArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseCharArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jshortArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseShortArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jintArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseIntArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jlongArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseLongArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jfloatArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseFloatArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseDoubleArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+
+        template<typename T=TJArray>
+        inline
+        typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, void>
+        freeDataPtr(JEnv& env)
+        {
+            env->ReleaseBooleanArrayElements(jniArray, dataPtr, JNI_ABORT);
+        }
+    };
+public:
+    JArray(JEnv env, TJArray initArray)
+        : JObject(env, static_cast<jobject>(initArray))
+    {}
+    JArray(TJArray initArray)
+        : JArray(JVM::getEnv(), initArray)
+    {}
+
+    inline operator TCpp()
     {
-        return jniArray;
-    }
-    inline operator TJni() const
-    {
-        return jniArray;
-    }
-    inline TJniEl* data()
-    {
-        return dataPtr;
+        JArrayData data(static_cast<TJArray>(jniObject));
+        return static_cast<TCpp>(data);
     }
 
-    template<typename T=TJni>
+    inline operator TJArray() const
+    {
+        return static_cast<TJArray>(jniObject);
+    }
+
+//    inline TJArrayElement* data()
+//    {
+//        return dataPtr;
+//    }
+
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jbyteArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jbyteArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewByteArray(vector.size());
-        env->SetByteArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewByteArray(vector.size());
+        env->SetByteArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jcharArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jcharArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewCharArray(vector.size());
-        env->SetCharArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewCharArray(vector.size());
+        env->SetCharArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jshortArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jshortArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewShortArray(vector.size());
-        env->SetShortArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewShortArray(vector.size());
+        env->SetShortArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jintArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jintArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewIntArray(vector.size());
-        env->SetIntArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewIntArray(vector.size());
+        env->SetIntArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jlongArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jlongArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewLongArray(vector.size());
-        env->SetLongArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewLongArray(vector.size());
+        env->SetLongArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jfloatArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jfloatArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewFloatArray(vector.size());
-        env->SetFloatArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewFloatArray(vector.size());
+        env->SetFloatArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewDoubleArray(vector.size());
-        env->SetDoubleArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewDoubleArray(vector.size());
+        env->SetDoubleArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
+    template<typename T=TJArray>
     static inline
-    typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, TJni>
+    typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, JArray<TCpp, T, TJArrayElement>>
     createFrom(JEnv env, const TCpp& vector)
     {
-        TJni a = env->NewBooleanArray(vector.size());
-        env->SetBooleanArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJniEl*>(vector.data()));
+        TJArray a = env->NewBooleanArray(vector.size());
+        env->SetBooleanArrayRegion(a, 0, vector.size(), reinterpret_cast<const TJArrayElement*>(vector.data()));
         return a;
     }
 
-    template<typename T=TJni>
-    static inline auto createFrom(const TCpp& vector)
+    static inline JArray<TCpp, TJArray, TJArrayElement> createFrom(const TCpp& vector)
     {
         return createFrom(JVM::getEnv(), vector);
     }
 
-private:
-    std::size_t length { 0 };
-    TJni jniArray { nullptr };
-    TJniEl* dataPtr { nullptr };
-
-    void init(JEnv env)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jbyteArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        if (jniArray)
-        {
-            length = env->GetArrayLength(jniArray);
-            dataPtr = getDataPtr<TJni>(env);
-        }
+        return env->NewByteArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jbyteArray>, void>
-    create(JEnv env, std::size_t initSize)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jcharArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        jniArray = env->NewByteArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jcharArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewCharArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jshortArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewShortArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jintArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewIntArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jlongArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewLongArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jfloatArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewFloatArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewDoubleArray(static_cast<jsize>(initSize));
-    }
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, void>
-    create(JEnv env, std::size_t initSize)
-    {
-        jniArray = env->NewBooleanArray(static_cast<jsize>(initSize));
+        return env->NewCharArray(static_cast<jsize>(initSize));
     }
 
-    void dispose()
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jshortArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        if (jniArray && dataPtr)
-        {
-            auto env = JVM::getEnv();
-            freeDataPtr<TJni>(env);
-            length = 0;
-            dataPtr = nullptr;
-        }
+        return env->NewShortArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jcharArray>, TJniEl*>
-    getDataPtr(JEnv& env)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jintArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        return env->GetCharArrayElements(jniArray, nullptr);
+        return env->NewIntArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jbyteArray>, TJniEl*>
-    getDataPtr(JEnv& env)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jlongArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        return env->GetByteArrayElements(jniArray, nullptr);
+        return env->NewLongArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jshortArray>, TJniEl*>
-    getDataPtr(JEnv& env)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jfloatArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        return env->GetShortArrayElements(jniArray, nullptr);
+        return env->NewFloatArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jintArray>, TJniEl*>
-    getDataPtr(JEnv& env)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        return env->GetIntArrayElements(jniArray, nullptr);
+        return env->NewDoubleArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jlongArray>, TJniEl*>
-    getDataPtr(JEnv& env)
+    template<typename T=TJArray>
+    static inline
+    typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, JArray<TCpp, T, TJArrayElement>>
+    createNew(JEnv env, std::size_t initSize)
     {
-        return env->GetLongArrayElements(jniArray, nullptr);
+        return env->NewBooleanArray(static_cast<jsize>(initSize));
     }
 
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jfloatArray>, TJniEl*>
-    getDataPtr(JEnv& env)
+    static inline JArray<TCpp, TJArray, TJArrayElement> createNew(std::size_t initSize)
     {
-        return env->GetFloatArrayElements(jniArray, nullptr);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, TJniEl*>
-    getDataPtr(JEnv& env)
-    {
-        return env->GetDoubleArrayElements(jniArray, nullptr);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, TJniEl*>
-    getDataPtr(JEnv& env)
-    {
-        return env->GetBooleanArrayElements(jniArray, nullptr);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jbyteArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseByteArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jcharArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseCharArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jshortArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseShortArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jintArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseIntArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jlongArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseLongArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jfloatArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseFloatArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jdoubleArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseDoubleArrayElements(jniArray, dataPtr, JNI_ABORT);
-    }
-
-    template<typename T>
-    inline
-    typename std::enable_if_t<std::is_same_v<T, jbooleanArray>, void>
-    freeDataPtr(JEnv& env)
-    {
-        env->ReleaseBooleanArrayElements(jniArray, dataPtr, JNI_ABORT);
+        return createNew(JVM::getEnv(), initSize);
     }
 
 };

--- a/include/Jni/JClass.hpp
+++ b/include/Jni/JClass.hpp
@@ -137,7 +137,7 @@ public:
         {
             throw std::runtime_error(std::string("Failed to reate Java object "));
         }
-        return JObject(obj, true);
+        return static_cast<JObject>(obj);
     }
 
     template<typename... TArgs>
@@ -539,7 +539,7 @@ private:
         T
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept {
-        return JObject(getFieldValue<jobject>(env, fieldId), true);
+        return static_cast<JObject>(getFieldValue<jobject>(env, fieldId));
     }
 
     template<typename T>

--- a/include/Jni/JClass.hpp
+++ b/include/Jni/JClass.hpp
@@ -706,7 +706,7 @@ inline jfieldID JObject::getFieldIdJni(JEnv& env, const std::string& name, const
 
 inline JClass JObject::getClass(JEnv& env) const noexcept
 {
-    return env.getObjectClass(obj);
+    return env.getObjectClass(jniObject);
 }
 
 inline JClass JObject::getClass() const noexcept

--- a/include/Jni/JEnv.hpp
+++ b/include/Jni/JEnv.hpp
@@ -1,7 +1,6 @@
 #ifndef __GUSC_JENV_HPP
 #define __GUSC_JENV_HPP 1
 
-#include <jni.h>
 #include <memory>
 
 namespace gusc::Jni

--- a/include/Jni/JEnv.hpp
+++ b/include/Jni/JEnv.hpp
@@ -2,6 +2,7 @@
 #define __GUSC_JENV_HPP 1
 
 #include <jni.h>
+#include <memory>
 
 namespace gusc::Jni
 {
@@ -11,9 +12,25 @@ class JClass;
 class JEnv
 {
 public:
-    JEnv(JNIEnv* initEnv) :
-        env(initEnv) {}
-    
+    /// @brief Wrapped instance of JNIEnv object without thread attachment lifetime watch
+    JEnv(JNIEnv* initEnv)
+        : env(initEnv)
+    {}
+
+    /// @brief Wrapped instance of JNIEnv object with thread attachment lifetime watch
+    /// This class hosts a shared pointer that get's passed between all copies of this object
+    /// once the last copy is deleted the current thread is detached from JavaVM
+    JEnv(JNIEnv* initEnv, JavaVM* initVm)
+        : env(initEnv)
+        , lifetimeHandle(std::make_shared<JEnvLifetimeHandle>(initVm))
+    {}
+
+    JEnv(const JEnv&) = default;
+    JEnv& operator=(const JEnv&) = default;
+    JEnv(JEnv&&) = default;
+    JEnv& operator=(JEnv&&) = default;
+    ~JEnv() = default;
+
     JClass getClass(const char* classPath);
 
     JClass getObjectClass(jobject jniObject);
@@ -31,7 +48,24 @@ public:
     static void checkException(JEnv& env);
 
 private:
+    struct JEnvLifetimeHandle
+    {
+        JEnvLifetimeHandle(JavaVM* initVm)
+            : vm(initVm)
+        {}
+        ~JEnvLifetimeHandle()
+        {
+            if (vm)
+            {
+                vm->DetachCurrentThread();
+                vm = nullptr;
+            }
+        }
+        JavaVM* vm { nullptr };
+    };
+
     JNIEnv* env { nullptr };
+    std::shared_ptr<JEnvLifetimeHandle> lifetimeHandle;
 };
     
 }

--- a/include/Jni/JGlobalRef.hpp
+++ b/include/Jni/JGlobalRef.hpp
@@ -16,7 +16,7 @@ public:
     /// @brief create global reference to JNI object and wrap it
     /// @note this automatically assumes the ownership of the global reference object
     JGlobalRef(jobject initObj)
-        : obj(JVM::getEnv()->NewGlobalRef(initObj), true)
+        : obj(static_cast<JObject>(initObj).createGlobalRef())
     {}
     JGlobalRef(const JGlobalRef&) = delete;
     JGlobalRef& operator=(const JGlobalRef&) = delete;

--- a/include/Jni/JObject.hpp
+++ b/include/Jni/JObject.hpp
@@ -10,13 +10,6 @@ namespace gusc::Jni
 class JClass;
 class JString;
 
-// TODO:
-// 1. make JArray and JString objects extend from JObject
-// 2. drop current ownership in favor of always creating a reference copy
-// 3. make it possible to copy objects taking into account their reference type (global, local, weak)
-// note: maybe 2&3 can be somehow combined with some optimization for when creating object from raw
-//       jtype we do not copy reference, but if we copy from JObject to another then we do
-// 4. instead of JGlobalRef create method in JObject to create global or weak references that just copies the object
 class JObject
 {
 public:

--- a/include/Jni/JObject.hpp
+++ b/include/Jni/JObject.hpp
@@ -17,14 +17,14 @@ class JString;
 // note: maybe 2&3 can be somehow combined with some optimization for when creating object from raw
 //       jtype we do not copy reference, but if we copy from JObject to another then we do
 // 4. instead of JGlobalRef create method in JObject to create global or weak references that just copies the object
-class JObject final
+class JObject
 {
 public:
     /// @brief create empty JNI object wrapper
     JObject() = default;
-    explicit JObject(const jobject& initObject)
+    /// @brief wrap around an existing JNI object
+    JObject(JEnv env, const jobject& initObject)
     {
-        auto env = JVM::getEnv();
         if (env->GetObjectRefType(initObject) == JNIGlobalRefType)
         {
             jniObject = env->NewLocalRef(initObject);
@@ -38,6 +38,9 @@ public:
             jniObject = env->NewGlobalRef(initObject);
         }
     }
+    JObject(const jobject& initObject)
+        : JObject(JVM::getEnv(), initObject)
+    {}
     JObject(const JObject& other)
     {
         auto env = JVM::getEnv();

--- a/include/Jni/JObject.hpp
+++ b/include/Jni/JObject.hpp
@@ -1,10 +1,6 @@
 #ifndef __GUSC_JOBJECT_HPP
 #define __GUSC_JOBJECT_HPP 1
 
-#include <jni.h>
-#include "JVM.hpp"
-#include "JEnv.hpp"
-#include "JString.hpp"
 #include "private/concat.hpp"
 #include "private/signature.hpp"
 
@@ -12,6 +8,7 @@ namespace gusc::Jni
 {
 
 class JClass;
+class JString;
 
 // TODO:
 // 1. make JArray and JString objects extend from JObject
@@ -421,10 +418,7 @@ protected:
         std::is_same_v<TReturn, JString>,
         TReturn
     >
-    invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
-    {
-        return JString(invokeMethodReturn<jstring>(env, methodId, std::forward<const TArgs&>(args)...));
-    }
+    invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept;
 
     template<typename TReturn, typename... TArgs>
     inline
@@ -551,10 +545,7 @@ protected:
         std::is_same_v<T, JString>,
         T
     >
-    getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
-    {
-        return JString(getFieldValue<jstring>(env, fieldId));
-    }
+    getFieldValue(JEnv& env, jfieldID fieldId) const noexcept;
 
     template<typename T>
     inline

--- a/include/Jni/JObject.hpp
+++ b/include/Jni/JObject.hpp
@@ -27,59 +27,59 @@ public:
         auto env = JVM::getEnv();
         if (env->GetObjectRefType(initObject) == JNIGlobalRefType)
         {
-            obj = env->NewLocalRef(initObject);
+            jniObject = env->NewLocalRef(initObject);
         }
         else if (env->GetObjectRefType(initObject) == JNIWeakGlobalRefType)
         {
-            obj = env->NewWeakGlobalRef(initObject);
+            jniObject = env->NewWeakGlobalRef(initObject);
         }
         else
         {
-            obj = env->NewGlobalRef(initObject);
+            jniObject = env->NewGlobalRef(initObject);
         }
     }
     JObject(const JObject& other)
     {
         auto env = JVM::getEnv();
-        if (env->GetObjectRefType(other.obj) == JNIGlobalRefType)
+        if (env->GetObjectRefType(other.jniObject) == JNIGlobalRefType)
         {
-            obj = env->NewLocalRef(other.obj);
+            jniObject = env->NewLocalRef(other.jniObject);
         }
-        else if (env->GetObjectRefType(other.obj) == JNIWeakGlobalRefType)
+        else if (env->GetObjectRefType(other.jniObject) == JNIWeakGlobalRefType)
         {
-            obj = env->NewWeakGlobalRef(other.obj);
+            jniObject = env->NewWeakGlobalRef(other.jniObject);
         }
         else
         {
-            obj = env->NewGlobalRef(other.obj);
+            jniObject = env->NewGlobalRef(other.jniObject);
         }
     }
     JObject& operator=(const JObject& other)
     {
         auto env = JVM::getEnv();
-        if (env->GetObjectRefType(other.obj) == JNIGlobalRefType)
+        if (env->GetObjectRefType(other.jniObject) == JNIGlobalRefType)
         {
-            obj = env->NewLocalRef(other.obj);
+            jniObject = env->NewLocalRef(other.jniObject);
         }
-        else if (env->GetObjectRefType(other.obj) == JNIWeakGlobalRefType)
+        else if (env->GetObjectRefType(other.jniObject) == JNIWeakGlobalRefType)
         {
-            obj = env->NewWeakGlobalRef(other.obj);
+            jniObject = env->NewWeakGlobalRef(other.jniObject);
         }
         else
         {
-            obj = env->NewGlobalRef(other.obj);
+            jniObject = env->NewGlobalRef(other.jniObject);
         }
         return *this;
     }
     JObject(JObject&& other)
-        : obj(other.obj)
+        : jniObject(other.jniObject)
     {
-        std::swap(obj, other.obj);
+        std::swap(jniObject, other.jniObject);
     }
     JObject& operator=(JObject&& other)
     {
         dispose();
-        std::swap(obj, other.obj);
+        std::swap(jniObject, other.jniObject);
         return *this;
     }
     ~JObject()
@@ -92,7 +92,7 @@ public:
     {
         auto env = JVM::getEnv();
         JObject other;
-        other.obj = env->NewGlobalRef(obj);
+        other.jniObject = env->NewGlobalRef(jniObject);
         return other;
     }
 
@@ -101,18 +101,18 @@ public:
     {
         auto env = JVM::getEnv();
         JObject other;
-        other.obj = env->NewWeakGlobalRef(obj);
+        other.jniObject = env->NewWeakGlobalRef(jniObject);
         return other;
     }
 
     inline operator bool() const
     {
-        return obj != nullptr;
+        return jniObject != nullptr;
     }
 
     inline operator jobject() const
     {
-        return obj;
+        return jniObject;
     }
 
     /// @brief Release the wrapped object.
@@ -120,7 +120,7 @@ public:
     inline jobject release()
     {
         jobject tmp { nullptr };
-        std::swap(obj, tmp);
+        std::swap(jniObject, tmp);
         return tmp;
     }
 
@@ -269,39 +269,39 @@ public:
     }
 
 protected:
-    jobject obj { nullptr };
+    jobject jniObject { nullptr };
 
     void dispose()
     {
-        if (obj)
+        if (jniObject)
         {
             auto env = JVM::getEnv();
-            if (env->GetObjectRefType(obj) == JNIGlobalRefType)
+            if (env->GetObjectRefType(jniObject) == JNIGlobalRefType)
             {
-                env->DeleteGlobalRef(obj);
+                env->DeleteGlobalRef(jniObject);
             }
-            else if (env->GetObjectRefType(obj) == JNIWeakGlobalRefType)
+            else if (env->GetObjectRefType(jniObject) == JNIWeakGlobalRefType)
             {
-                env->DeleteWeakGlobalRef(obj);
+                env->DeleteWeakGlobalRef(jniObject);
             }
             else
             {
-                env->DeleteLocalRef(obj);
+                env->DeleteLocalRef(jniObject);
             }
-            obj = nullptr;
+            jniObject = nullptr;
         }
     }
 
     inline void invokeMethodReturnVoid(JEnv& env, jmethodID methodId) const noexcept
     {
-        env->CallVoidMethod(obj, methodId);
+        env->CallVoidMethod(jniObject, methodId);
     }
 
     template<typename... TArgs>
     inline
     void invokeMethodReturnVoid(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        env->CallVoidMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        env->CallVoidMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -312,7 +312,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallBooleanMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallBooleanMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -323,7 +323,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallCharMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallCharMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -334,7 +334,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallByteMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallByteMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -345,7 +345,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallShortMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallShortMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -356,7 +356,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallIntMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallIntMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -367,7 +367,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallLongMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallLongMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -378,7 +378,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallFloatMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallFloatMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -389,7 +389,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return env->CallDoubleMethod(obj, methodId, std::forward<const TArgs&>(args)...);
+        return env->CallDoubleMethod(jniObject, methodId, std::forward<const TArgs&>(args)...);
     }
 
     template<typename TReturn, typename... TArgs>
@@ -409,7 +409,7 @@ protected:
     >
     invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
     {
-        return static_cast<TReturn>(env->CallObjectMethod(obj, methodId, std::forward<const TArgs&>(args)...));
+        return static_cast<TReturn>(env->CallObjectMethod(jniObject, methodId, std::forward<const TArgs&>(args)...));
     }
 
     template<typename TReturn, typename... TArgs>
@@ -439,7 +439,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetBooleanField(obj, fieldId);
+        return env->GetBooleanField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -450,7 +450,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetCharField(obj, fieldId);
+        return env->GetCharField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -461,7 +461,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetByteField(obj, fieldId);
+        return env->GetByteField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -472,7 +472,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetShortField(obj, fieldId);
+        return env->GetShortField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -483,7 +483,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetIntField(obj, fieldId);
+        return env->GetIntField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -494,7 +494,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetLongField(obj, fieldId);
+        return env->GetLongField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -505,7 +505,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetFloatField(obj, fieldId);
+        return env->GetFloatField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -516,7 +516,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return env->GetDoubleField(obj, fieldId);
+        return env->GetDoubleField(jniObject, fieldId);
     }
 
     template<typename T>
@@ -536,7 +536,7 @@ protected:
     >
     getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
     {
-        return static_cast<T>(env->GetObjectField(obj, fieldId));
+        return static_cast<T>(env->GetObjectField(jniObject, fieldId));
     }
 
     template<typename T>
@@ -565,7 +565,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetBooleanField(obj, fieldId, value);
+        env->SetBooleanField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -575,7 +575,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetCharField(obj, fieldId, value);
+        env->SetCharField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -585,7 +585,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetByteField(obj, fieldId, value);
+        env->SetByteField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -595,7 +595,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetShortField(obj, fieldId, value);
+        env->SetShortField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -605,7 +605,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetIntField(obj, fieldId, value);
+        env->SetIntField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -615,7 +615,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetLongField(obj, fieldId, value);
+        env->SetLongField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -625,7 +625,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetFloatField(obj, fieldId, value);
+        env->SetFloatField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -635,7 +635,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetDoubleField(obj, fieldId, value);
+        env->SetDoubleField(jniObject, fieldId, value);
     }
 
     template<typename T>
@@ -654,7 +654,7 @@ protected:
                                   const T&
                               > value) noexcept
     {
-        env->SetObjectField(obj, fieldId, static_cast<jobject>(value));
+        env->SetObjectField(jniObject, fieldId, static_cast<jobject>(value));
     }
 
     template<typename T>

--- a/include/Jni/JString.hpp
+++ b/include/Jni/JString.hpp
@@ -29,6 +29,11 @@ class JString final: public JObject
             return std::string(dataPtr, dataPtr + length);
         }
 
+        inline const char* data() const
+        {
+            return dataPtr;
+        }
+
         ~JStringData()
         {
             if (jniString && dataPtr)
@@ -60,6 +65,11 @@ public:
     }
 
     inline operator jstring() const
+    {
+        return static_cast<jstring>(jniObject);
+    }
+
+    inline JStringData getData() const
     {
         return static_cast<jstring>(jniObject);
     }

--- a/include/Jni/JString.hpp
+++ b/include/Jni/JString.hpp
@@ -88,6 +88,28 @@ private:
     }
 };
 
+template<typename T>
+inline
+typename std::enable_if_t<
+        std::is_same_v<T, JString>,
+        T
+>
+JObject::getFieldValue(JEnv& env, jfieldID fieldId) const noexcept
+{
+    return JString(getFieldValue<jstring>(env, fieldId));
+}
+
+template<typename TReturn, typename... TArgs>
+inline
+typename std::enable_if_t<
+        std::is_same_v<TReturn, JString>,
+        TReturn
+>
+JObject::invokeMethodReturn(JEnv& env, jmethodID methodId, const TArgs&... args) const noexcept
+{
+    return JString(invokeMethodReturn<jstring>(env, methodId, std::forward<const TArgs&>(args)...));
+}
+
 }
 
 #endif // __GUSC_JSTRING_HPP

--- a/include/Jni/JString.hpp
+++ b/include/Jni/JString.hpp
@@ -11,12 +11,11 @@ class JString final: public JObject
     class JStringData final
     {
     public:
-        JStringData(const jstring& initString)
+        JStringData(JEnv env, const jstring& initString)
             : jniString(initString)
         {
             if (jniString)
             {
-                auto env = JVM::getEnv();
                 length = env->GetStringUTFLength(jniString);
                 dataPtr = env->GetStringUTFChars(jniString, nullptr);
             }
@@ -60,7 +59,7 @@ public:
 
     inline operator std::string() const
     {
-        JStringData data(static_cast<jstring>(jniObject));
+        JStringData data(JVM::getEnv(), static_cast<jstring>(jniObject));
         return static_cast<std::string>(data);
     }
 
@@ -71,7 +70,7 @@ public:
 
     inline JStringData getData() const
     {
-        return static_cast<jstring>(jniObject);
+        return JStringData(JVM::getEnv(), static_cast<jstring>(jniObject));
     }
 
     inline static JString createFrom(JEnv env, const std::string& str)

--- a/include/Jni/JString.hpp
+++ b/include/Jni/JString.hpp
@@ -1,90 +1,77 @@
 #ifndef __GUSC_JSTRING_HPP
 #define __GUSC_JSTRING_HPP 1
 
-#include <jni.h>
-#include "JVM.hpp"
-#include "JEnv.hpp"
-
 #include <string>
 
 namespace gusc::Jni
 {
 
-class JString
+class JString final: public JObject
 {
-public:
-    JString(JEnv env, const jstring& initString)
+    class JStringData final
+    {
+    public:
+        JStringData(const jstring& initString)
             : jniString(initString)
-    {
-        if (jniString)
         {
-            length = env->GetStringUTFLength(jniString);
-            dataPtr = env->GetStringUTFChars(jniString, nullptr);
+            if (jniString)
+            {
+                auto env = JVM::getEnv();
+                length = env->GetStringUTFLength(jniString);
+                dataPtr = env->GetStringUTFChars(jniString, nullptr);
+            }
         }
-    }
-    JString(const jstring& initString) : JString(JVM::getEnv(), initString)
-    {}
-    JString(const JString& other) = delete;
-    JString& operator=(const JString& other) = delete;
-    JString(JString&& other) = default;
-    JString& operator=(JString&& other)
-    {
-        dispose();
-        jniString = nullptr;
-        std::swap(jniString, other.jniString);
-        std::swap(length, other.length);
-        std::swap(dataPtr, other.dataPtr);
-        return *this;
-    }
-    ~JString()
-    {
-        dispose();
-    }
-    operator std::string()
-    {
-        if (dataPtr)
+        JStringData(const JStringData&) = delete;
+        JStringData& operator=(const JStringData&) = delete;
+
+        inline operator std::string() const
         {
             return std::string(dataPtr, dataPtr + length);
         }
-        return {};
-    }
-    operator jstring()
+
+        ~JStringData()
+        {
+            if (jniString && dataPtr)
+            {
+                auto env = JVM::getEnv();
+                env->ReleaseStringUTFChars(jniString, dataPtr);
+                dataPtr = nullptr;
+                length = 0;
+            }
+        }
+    private:
+        jstring jniString { nullptr };
+        std::size_t length { 0 };
+        const char* dataPtr { nullptr };
+    };
+public:
+    /// @brief wrap around existing JNI jstring object
+    JString(JEnv env, const jstring& initString)
+        : JObject(env,static_cast<jobject>(initString))
+    {}
+    JString(const jstring& initString)
+        : JString(JVM::getEnv(), initString)
+    {}
+
+    inline operator std::string() const
     {
-        return jniString;
-    }
-    operator jstring() const
-    {
-        return jniString;
-    }
-    inline const char* data()
-    {
-        return dataPtr;
+        JStringData data(static_cast<jstring>(jniObject));
+        return static_cast<std::string>(data);
     }
 
-    static JString createFrom(JEnv env, const std::string& str)
+    inline operator jstring() const
     {
-        return JString(env, env->NewStringUTF(str.c_str()));
+        return static_cast<jstring>(jniObject);
     }
 
-    static JString createFrom(const std::string& str)
+    inline static JString createFrom(JEnv env, const std::string& str)
+    {
+        return JString(env->NewStringUTF(str.c_str()));
+    }
+
+    inline static JString createFrom(const std::string& str)
     {
         return createFrom(JVM::getEnv(), str);
-    }
-
-private:
-    std::size_t length { 0 };
-    jstring jniString { nullptr };
-    const char* dataPtr { nullptr };
-
-    void dispose()
-    {
-        if (jniString && dataPtr)
-        {
-            auto env = JVM::getEnv();
-            env->ReleaseStringUTFChars(jniString, dataPtr);
-            dataPtr = nullptr;
-            length = 0;
-        }
     }
 };
 

--- a/include/Jni/JVM.hpp
+++ b/include/Jni/JVM.hpp
@@ -1,11 +1,7 @@
 #ifndef __GUSC_JVM_HPP
 #define __GUSC_JVM_HPP 1
 
-#include <jni.h>
-
 #include <stdexcept>
-
-#include "JEnv.hpp"
 
 namespace gusc::Jni
 {

--- a/include/Jni/JVM.hpp
+++ b/include/Jni/JVM.hpp
@@ -29,10 +29,21 @@ public:
             }
             else if (res == JNI_EDETACHED && vm->AttachCurrentThread(&env, nullptr) == JNI_OK)
             {
-                return JEnv(env);
+                return JEnv(env, vm);
             }
         }
         throw std::runtime_error("Java ENV cannot be created!");
+    }
+    static inline void detachThread()
+    {
+        if (vm)
+        {
+            if (vm->DetachCurrentThread() == JNI_OK)
+            {
+                return;
+            }
+        }
+        throw std::runtime_error("Java can not detach from thread!");
     }
 private:
     inline static JavaVM* vm { nullptr };

--- a/include/Jni/Jni.hpp
+++ b/include/Jni/Jni.hpp
@@ -2,11 +2,11 @@
 #define __GUSC_JNI_HPP 1
 
 #include <jni.h>
-#include "JVM.hpp"
 #include "JEnv.hpp"
-#include "JString.hpp"
-#include "JClass.hpp"
+#include "JVM.hpp"
 #include "JObject.hpp"
+#include "JClass.hpp"
+#include "JString.hpp"
 #include "JArray.hpp"
 #include "JGlobalRef.hpp"
 

--- a/include/Jni/private/signature.hpp
+++ b/include/Jni/private/signature.hpp
@@ -2,7 +2,11 @@
 #define __GUSC_PRIVATE_SIGNATURE_HPP 1
 
 #include "concat.hpp"
-#include <jni.h>
+
+namespace gusc::Jni
+{
+class JString;
+}
 
 namespace gusc::Jni::Private
 {


### PR DESCRIPTION
* Change the jobject ownership logic - make new reference on copy keeping reference type (local, weak, global)
* JString and JArray are now based on JObject, so they have full method and member access APIs
* RAII detacher from native thread for JEnv